### PR TITLE
Automatically stop the tegral environment on jvm shutdown hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Added `filterSubclassesOf` function, which is especially useful for
     writing extensions. ([#23](https://github.com/utybo/Tegral/pull/23))
 
+    - `filterSubclassesOf` also properly works with Proxies (e.g. MockK mocks)
+      ([#29](https://github.com/utybo/Tegral/pull/29))
+
 - `tegral-di-test`
 
   - `UnsafeMutableEnvironment` is now an extensible environment.
@@ -49,6 +52,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `tegral-logging`
 
   - Added logging configuration. You can now configure loggers directly in your `tegral.toml` -- Logback will be configured accordingly. ([#10](https://github.com/utybo/Tegral/pull/10))
+
+  - Added a `putLoggerFactory` function to easily add factories to any
+    environment, especially ones that do not have features support.
+    ([#29](https://github.com/utybo/Tegral/pull/29))
 
 - `tegral-openapi-cli`
 
@@ -99,6 +106,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     ([#17](https://github.com/utybo/Tegral/pull/17))
 
   - Added an automatic default configuration for logging. This creates a better logging experience out of the box than the Logback defaults. ([#10](https://github.com/utybo/Tegral/pull/10))
+
+  - Tegral will now stop all services when receiving a shutdown hook from the
+    JVM (done via the `ShutdownHookService`).
+    ([#29](https://github.com/utybo/Tegral/pull/29))
 
 - `tegral-web-appdsl`
 
@@ -226,11 +237,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - `tegral-di-services`
+
   - The services extension now properly detects services where the "advertised"
     type is not a `TegralService`, but the type of the actual object is. For
     example, if you have a `put<Contract>(::Implementation)` declaration, the
     services extension will properly detect services even if only
-    `Implementation` implements `TegralService`. ([#23](https://github.com/utybo/Tegral/pull/23))
+    `Implementation` implements `TegralService`.
+    ([#23](https://github.com/utybo/Tegral/pull/23))
+
+  - The services extension now properly detects services that are actually
+    mocks. ([#29](https://github.com/utybo/Tegral/pull/29))
+
+- `tegral-di-test`
+
+  - Fixed the error message when not using any DI check in a DI block showing
+    the old Shedinja way of adding rules.
+    ([#29](https://github.com/utybo/Tegral/pull/29))
 
 ## [0.0.1] - 2022-06-02
 

--- a/docs/docs/modules/web/appdefaults/index.mdx
+++ b/docs/docs/modules/web/appdefaults/index.mdx
@@ -18,6 +18,8 @@ It provides sane defaults for Web applications. Most notably:
 
 - It automatically configures the default loggers for a better out-of-the-box experience. For logger configuration, see the [Tegral Logging feature](/modules/core/logging/index.mdx).
 
+- It sets up a service that will stop the application in case a JVM shutdown hook is received (e.g. when `Ctrl+C`-ing the application).
+
 The AppDefaults feature also has a dependency on the Tegral Services feature and on [Tegral Web Controllers](/modules/web/controllers/index.mdx) and sets up the `[tegral.web]` configuration section (i.e. `WebConfiguration`)
 
 [AppDSL](/modules/web/appdsl/index.mdx) automatically installs AppDefaults, meaning that you do not need to install AppDefaults yourself if you use AppDSL.

--- a/examples/simple-json-api/src/main/resources/tegral.toml
+++ b/examples/simple-json-api/src/main/resources/tegral.toml
@@ -1,2 +1,5 @@
 [tegral.web]
 port = 8080
+
+[tegral.logging.loggers."tegral.web.appdsl.stats"]
+level = "Debug"

--- a/tegral-di/tegral-di-core/src/main/kotlin/guru/zoroark/tegral/di/extensions/Utils.kt
+++ b/tegral-di/tegral-di-core/src/main/kotlin/guru/zoroark/tegral/di/extensions/Utils.kt
@@ -35,6 +35,10 @@ fun <T : Any> Sequence<Identifier<*>>.filterSubclassesOf(
     kclass: KClass<T>
 ): Sequence<Identifier<T>> =
     filter {
+        // KClass' isSubclassOf seems to be broken when using proxies (e.g. mocks), so we use Java's Class equivalents
+        // instead.
         (environment.getResolverOrNull(it) as? CanonicalIdentifierResolver<*>)
-            ?.actualClass?.isSubclassOf(kclass) ?: false
+            ?.actualClass?.java?.isSubclassOf(kclass) ?: false
     } as Sequence<Identifier<T>>
+
+private fun Class<*>.isSubclassOf(other: KClass<*>): Boolean = other.java.isAssignableFrom(this)

--- a/tegral-di/tegral-di-test/src/main/kotlin/guru/zoroark/tegral/di/test/check/ShedinjaCheck.kt
+++ b/tegral-di/tegral-di-test/src/main/kotlin/guru/zoroark/tegral/di/test/check/ShedinjaCheck.kt
@@ -86,7 +86,7 @@ private fun TegralDiCheckDsl.check() {
         throw TegralDiCheckException(
             """
             tegralDiCheck called without any rule, which checks nothing.
-            --> Add rules using +ruleName (for example '+complete', do not forget the +)
+            --> Add rules using ruleName() (for example 'complete()')
             --> If you do not want to run any checks, remove the tegralDiCheck block entirely.
             For more information, visit https://tegral.zoroark.guru/docs/core/di/testing/checks
             """.trimIndent()

--- a/tegral-di/tegral-di-test/src/test/kotlin/guru/zoroark/tegral/di/test/NoRulesCheckTest.kt
+++ b/tegral-di/tegral-di-test/src/test/kotlin/guru/zoroark/tegral/di/test/NoRulesCheckTest.kt
@@ -36,7 +36,7 @@ class NoRulesCheckTest {
         }.assertMessage(
             """
             tegralDiCheck called without any rule, which checks nothing.
-            --> Add rules using +ruleName (for example '+complete', do not forget the +)
+            --> Add rules using ruleName() (for example 'complete()')
             --> If you do not want to run any checks, remove the tegralDiCheck block entirely.
             For more information, visit https://tegral.zoroark.guru/docs/core/di/testing/checks
             """.trimIndent()

--- a/tegral-logging/api/tegral-logging.api
+++ b/tegral-logging/api/tegral-logging.api
@@ -60,3 +60,7 @@ public final class guru/zoroark/tegral/logging/LoggingFeature : guru/zoroark/teg
 	public fun onConfigurationLoaded (Lguru/zoroark/tegral/config/core/RootConfig;)V
 }
 
+public final class guru/zoroark/tegral/logging/LoggingFeatureKt {
+	public static final fun putLoggerFactory (Lguru/zoroark/tegral/di/dsl/ContextBuilderDsl;)V
+}
+

--- a/tegral-logging/src/main/kotlin/guru/zoroark/tegral/logging/LoggingFeature.kt
+++ b/tegral-logging/src/main/kotlin/guru/zoroark/tegral/logging/LoggingFeature.kt
@@ -17,6 +17,8 @@ package guru.zoroark.tegral.logging
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.LoggerContext
 import guru.zoroark.tegral.config.core.RootConfig
+import guru.zoroark.tegral.core.TegralDsl
+import guru.zoroark.tegral.di.dsl.ContextBuilderDsl
 import guru.zoroark.tegral.di.extensions.ExtensibleContextBuilderDsl
 import guru.zoroark.tegral.di.extensions.factory.putFactory
 import guru.zoroark.tegral.featureful.ConfigurableFeature
@@ -37,7 +39,7 @@ object LoggingFeature : ConfigurableFeature, LifecycleHookedFeature {
     override val configurationSections = listOf(LoggingConfig)
 
     override fun ExtensibleContextBuilderDsl.install() {
-        putFactory<Slf4jLogger> { requester -> LoggerFactory.getLogger(requester::class.loggerName) }
+        putLoggerFactory()
     }
 
     // Setup for the LoggingFeature is done right after the configuration is loaded and not during the regular "service
@@ -67,4 +69,14 @@ private fun LogLevel.toLogbackLevel(): Level = when (this) {
     LogLevel.Warn -> Level.WARN
     LogLevel.Error -> Level.ERROR
     LogLevel.Off -> Level.OFF
+}
+
+/**
+ * Adds Tegral Logging's `Logger` factory to this context builder. You do not need to call this if you are using the
+ * Tegral Logging feature. This is mostly useful for manually adding logging in test environments that do not support
+ * features (i.e. every Tegral test except integration tests).
+ */
+@TegralDsl
+fun ContextBuilderDsl.putLoggerFactory() {
+    putFactory<Slf4jLogger> { requester -> LoggerFactory.getLogger(requester::class.loggerName) }
 }

--- a/tegral-web/tegral-web-appdefaults/api/tegral-web-appdefaults.api
+++ b/tegral-web/tegral-web-appdefaults/api/tegral-web-appdefaults.api
@@ -37,6 +37,12 @@ public final class guru/zoroark/tegral/web/appdefaults/LoggingOverridesKt {
 	public static final fun applyLoggingOverrides ()V
 }
 
+public final class guru/zoroark/tegral/web/appdefaults/ShutdownHookService : guru/zoroark/tegral/services/api/TegralService {
+	public fun <init> (Lguru/zoroark/tegral/di/environment/InjectionScope;)V
+	public fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class guru/zoroark/tegral/web/appdefaults/TegralConfigurationContainer : guru/zoroark/tegral/config/core/RootConfig {
 	public fun <init> (Lguru/zoroark/tegral/config/core/TegralConfig;)V
 	public final fun component1 ()Lguru/zoroark/tegral/config/core/TegralConfig;

--- a/tegral-web/tegral-web-appdefaults/src/main/kotlin/guru/zoroark/tegral/web/appdefaults/AppDefaultsFeature.kt
+++ b/tegral-web/tegral-web-appdefaults/src/main/kotlin/guru/zoroark/tegral/web/appdefaults/AppDefaultsFeature.kt
@@ -39,5 +39,7 @@ object AppDefaultsFeature : ConfigurableFeature {
         put(::DefaultKtorApplication)
         put(::DefaultAppDefaultsModule)
         put(::KeepAliveService)
+        put(::RuntimeProvider)
+        put(::ShutdownHookService)
     }
 }

--- a/tegral-web/tegral-web-appdefaults/src/main/kotlin/guru/zoroark/tegral/web/appdefaults/ShutdownHookService.kt
+++ b/tegral-web/tegral-web-appdefaults/src/main/kotlin/guru/zoroark/tegral/web/appdefaults/ShutdownHookService.kt
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package guru.zoroark.tegral.web.appdefaults
+
+import guru.zoroark.tegral.di.environment.InjectionScope
+import guru.zoroark.tegral.di.environment.invoke
+import guru.zoroark.tegral.di.extensions.ExtensibleInjectionEnvironment
+import guru.zoroark.tegral.di.services.services
+import guru.zoroark.tegral.logging.LoggerName
+import guru.zoroark.tegral.services.api.TegralService
+import kotlinx.coroutines.runBlocking
+import org.slf4j.Logger
+
+// The Runtime object is exposed via DI like this to make testing easier.
+internal class RuntimeProvider {
+    val runtime: Runtime = Runtime.getRuntime()
+}
+
+/**
+ * A service that automatically calls `env.services.stopAll()` on the environment when a shutdown hook is received from
+ * the JVM.
+ */
+@LoggerName("tegral.shutdown")
+class ShutdownHookService(scope: InjectionScope) : TegralService {
+    private val logger: Logger by scope()
+    private val env: ExtensibleInjectionEnvironment by scope.meta()
+    private val runtimeProvider: RuntimeProvider by scope()
+
+    private val shutdownHook = Thread {
+        shutdownHookReceived()
+    }
+
+    override suspend fun start() {
+        runtimeProvider.runtime.addShutdownHook(shutdownHook)
+        logger.debug("Shutdown hook added.")
+    }
+
+    internal fun shutdownHookReceived() {
+        logger.info("Shutdown hook received, stopping application...")
+        runBlocking { env.services.stopAll { logger.info(it) } }
+        logger.info("Application has been stopped.")
+    }
+
+    override suspend fun stop() {
+        // no-op
+    }
+}

--- a/tegral-web/tegral-web-appdefaults/src/test/kotlin/guru/zoroark/tegral/web/appdefaults/ShutdownHookServiceTest.kt
+++ b/tegral-web/tegral-web-appdefaults/src/test/kotlin/guru/zoroark/tegral/web/appdefaults/ShutdownHookServiceTest.kt
@@ -65,4 +65,26 @@ class ShutdownHookServiceTest : TegralSubjectTest<ShutdownHookService>(
 
         coVerify { mockService.stop() }
     }
+
+    @Test
+    fun `Hook is removed when stopping manually`(): Unit = test {
+        useServices()
+        val runtime = mockk<Runtime> {
+            every { addShutdownHook(any()) } just runs
+            every { removeShutdownHook(any()) } returns true
+        }
+        putMock<RuntimeProvider> {
+            every { this@putMock.runtime } returns runtime
+        }
+
+        subject.start()
+
+        coVerify(exactly = 1) { runtime.addShutdownHook(any()) }
+        coVerify(exactly = 0) { runtime.removeShutdownHook(any()) }
+
+        subject.stop()
+
+        coVerify(exactly = 1) { runtime.addShutdownHook(any()) }
+        coVerify(exactly = 1) { runtime.removeShutdownHook(any()) }
+    }
 }

--- a/tegral-web/tegral-web-appdefaults/src/test/kotlin/guru/zoroark/tegral/web/appdefaults/ShutdownHookServiceTest.kt
+++ b/tegral-web/tegral-web-appdefaults/src/test/kotlin/guru/zoroark/tegral/web/appdefaults/ShutdownHookServiceTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package guru.zoroark.tegral.web.appdefaults
+
+import guru.zoroark.tegral.di.dsl.put
+import guru.zoroark.tegral.di.services.useServices
+import guru.zoroark.tegral.di.test.TegralSubjectTest
+import guru.zoroark.tegral.di.test.mockk.putMock
+import guru.zoroark.tegral.logging.putLoggerFactory
+import guru.zoroark.tegral.services.api.TegralService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verifyAll
+import kotlin.test.Test
+
+class ShutdownHookServiceTest : TegralSubjectTest<ShutdownHookService>(
+    ShutdownHookService::class,
+    {
+        put(::ShutdownHookService)
+        putLoggerFactory()
+    }
+) {
+    @Test
+    fun `Adds hook when started`(): Unit = test {
+        val runtime = mockk<Runtime> {
+            every { addShutdownHook(any()) } just runs
+        }
+        val rp = putMock<RuntimeProvider> {
+            every { this@putMock.runtime } returns runtime
+        }
+
+        subject.start()
+
+        verifyAll {
+            rp.runtime
+            runtime.addShutdownHook(any())
+        }
+    }
+
+    @Test
+    fun `Tests full application when started`(): Unit = test {
+        useServices()
+
+        val mockService = putMock<TegralService> {
+            coEvery { stop() } just runs
+        }
+
+        subject.shutdownHookReceived()
+
+        coVerify { mockService.stop() }
+    }
+}


### PR DESCRIPTION
Fixes #20

TODO

- [x] Ensure is removed when stopping the environment so that 
  - [x] A) Functional when Ctrl+C-ing twice (might be handled by the JVM)
  - [x] B) Functional when programmatically stopping, then Ctrl+C-ing (shouldn't cause another complete stop)
- [x] Update changelog
- [x] Update docs