### PR TITLE
Support Java 11 in published artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,28 @@ jobs:
       - name: Run check on example
         run: ./gradlew -p "examples/tutorial/${{ matrix.example }}" check --include-build ../../..
 
+  e2e-tests:
+      name: "Check end-to-end tests"
+      runs-on: ubuntu-latest
+      needs: [validate-wrapper]
+      strategy:
+        matrix:
+          test: ["run-with-java-11", "run-with-java-17"]
+      steps:
+        - uses: actions/checkout@v3
+
+        - uses: actions/setup-java@v3
+          with:
+            distribution: "temurin"
+            # Explicitly not LTS because some tests do some trickery around checking LTS compat
+            java-version: "18"
+
+        - name: Setup Gradle
+          uses: gradle/gradle-build-action@v2
+
+        - name: Run check on e2e test
+          run: ./gradlew -p "e2e-tests/${{ matrix.test }}" check
+
   build-dokka:
     name: "Generate Dokka files"
     runs-on: ubuntu-latest
@@ -110,7 +132,7 @@ jobs:
 
   build-deploy-website:
     name: Assemble and deploy website
-    needs: [validate-wrapper, build-docs, build-dokka, check, check-examples]
+    needs: [validate-wrapper, build-docs, build-dokka, check, check-examples, e2e-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -157,7 +179,7 @@ jobs:
     name: Publish snapshot
     if: "github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
-    needs: [validate-wrapper, check, check-examples]
+    needs: [validate-wrapper, check, check-examples, e2e-tests]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,28 +62,6 @@ jobs:
       - name: Run check on example
         run: ./gradlew -p "examples/tutorial/${{ matrix.example }}" check --include-build ../../..
 
-  e2e-tests:
-      name: "Check end-to-end tests"
-      runs-on: ubuntu-latest
-      needs: [validate-wrapper]
-      strategy:
-        matrix:
-          test: ["run-with-java-11", "run-with-java-17"]
-      steps:
-        - uses: actions/checkout@v3
-
-        - uses: actions/setup-java@v3
-          with:
-            distribution: "temurin"
-            # Explicitly not LTS because some tests do some trickery around checking LTS compat
-            java-version: "18"
-
-        - name: Setup Gradle
-          uses: gradle/gradle-build-action@v2
-
-        - name: Run check on e2e test
-          run: ./gradlew -p "e2e-tests/${{ matrix.test }}" check
-
   build-dokka:
     name: "Generate Dokka files"
     runs-on: ubuntu-latest
@@ -132,7 +110,7 @@ jobs:
 
   build-deploy-website:
     name: Assemble and deploy website
-    needs: [validate-wrapper, build-docs, build-dokka, check, check-examples, e2e-tests]
+    needs: [validate-wrapper, build-docs, build-dokka, check, check-examples]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -179,7 +157,7 @@ jobs:
     name: Publish snapshot
     if: "github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
-    needs: [validate-wrapper, check, check-examples, e2e-tests]
+    needs: [validate-wrapper, check, check-examples]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - General
 
+  - All packages can now be used with Java 11
+    ([#45](https://github.com/utybo/Tegral/pull/45))
+
   - Bumped Ktor version to version 2.0.3
     ([#17](https://github/utybo/Tegral/pull/17))
   

--- a/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-common-conventions.gradle
@@ -38,3 +38,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         jvmTarget = "11"
     }
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}

--- a/e2e-tests/run-with-java-11/build.gradle
+++ b/e2e-tests/run-with-java-11/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'guru.zoroark.tegral.kotlin-common-conventions'
+}
+
+dependencies {
+    implementation project(":tegral-di:tegral-di-core")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+

--- a/e2e-tests/run-with-java-11/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
+++ b/e2e-tests/run-with-java-11/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package guru.zoroark.tegral.e2e.lts
 
 import guru.zoroark.tegral.di.dsl.put
@@ -8,6 +22,7 @@ import kotlin.test.assertEquals
 
 class JavaLtsTest {
     class SomeComponent {
+        @Suppress("FunctionOnlyReturningConstant")
         fun sayHello() = "Hello!"
     }
 

--- a/e2e-tests/run-with-java-11/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
+++ b/e2e-tests/run-with-java-11/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
@@ -1,0 +1,23 @@
+package guru.zoroark.tegral.e2e.lts
+
+import guru.zoroark.tegral.di.dsl.put
+import guru.zoroark.tegral.di.dsl.tegralDi
+import guru.zoroark.tegral.di.environment.get
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JavaLtsTest {
+    class SomeComponent {
+        fun sayHello() = "Hello!"
+    }
+
+    // This is just a dumb test that uses APIs from Tegral libs.
+    @Test
+    fun `Simple DI test`() {
+        val env = tegralDi {
+            put(::SomeComponent)
+        }
+        val component = env.get<SomeComponent>()
+        assertEquals("Hello!", component.sayHello())
+    }
+}

--- a/e2e-tests/run-with-java-17/build.gradle
+++ b/e2e-tests/run-with-java-17/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'guru.zoroark.tegral.kotlin-common-conventions'
+}
+
+dependencies {
+    implementation project(":tegral-di:tegral-di-core")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+

--- a/e2e-tests/run-with-java-17/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
+++ b/e2e-tests/run-with-java-17/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package guru.zoroark.tegral.e2e.lts
 
 import guru.zoroark.tegral.di.dsl.put
@@ -8,6 +22,7 @@ import kotlin.test.assertEquals
 
 class JavaLtsTest {
     class SomeComponent {
+        @Suppress("FunctionOnlyReturningConstant")
         fun sayHello() = "Hello!"
     }
 

--- a/e2e-tests/run-with-java-17/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
+++ b/e2e-tests/run-with-java-17/src/test/kotlin/guru/zoroark/tegral/e2e/lts/JavaLtsTest.kt
@@ -1,0 +1,23 @@
+package guru.zoroark.tegral.e2e.lts
+
+import guru.zoroark.tegral.di.dsl.put
+import guru.zoroark.tegral.di.dsl.tegralDi
+import guru.zoroark.tegral.di.environment.get
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JavaLtsTest {
+    class SomeComponent {
+        fun sayHello() = "Hello!"
+    }
+
+    // This is just a dumb test that uses APIs from Tegral libs.
+    @Test
+    fun `Simple DI test`() {
+        val env = tegralDi {
+            put(::SomeComponent)
+        }
+        val component = env.get<SomeComponent>()
+        assertEquals("Hello!", component.sayHello())
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,9 @@ include 'tegral-catalog',
         'tegral-web:tegral-web-config',
         'tegral-web:tegral-web-controllers',
         'tegral-web:tegral-web-controllers-test',
-        'tegral-web:tegral-web-greeter'
+        'tegral-web:tegral-web-greeter',
+        'e2e-tests:run-with-java-11',
+        'e2e-tests:run-with-java-17'
 
 include 'examples:simple-json-api'
 


### PR DESCRIPTION
Currently, artifacts require Java 17 (as noted in #44) because they are built with Java 17. Should be set to 11 instead with tests to ensure that that it can actually be used.

Will fix #44 

### TODO

- [x] Ensure tests fail in CI
- [x] Add Java 11 as a target version *everywhere*...
- [x] ... and ensure the CI gets green after that
- [x] Update changelog