### PR TITLE
fix: updated index.mdx: Fixed supposedly missing word in footnote of Tegral Niwen's module page.

### DIFF
--- a/docs/docs/modules/core/niwen/index.mdx
+++ b/docs/docs/modules/core/niwen/index.mdx
@@ -166,7 +166,7 @@ From a very abstract perspective, when we think of parsing things, what we reall
 
 Compilation of programming languages is an example of something like this: compilers take in files (which are inherently strings of characters) and output some form of executable format.[^1]
 
-[^1]: This is a big simplification of the process that goes into the compilation programming languages. Parsing, as in looking at the file and extracting its structure into an *abstract syntax tree*, is usually the first step of this process.
+[^1]: This is a big simplification of the process that goes into the compilation of programming languages. Parsing, as in looking at the file and extracting its structure into an *abstract syntax tree*, is usually the first step of this process.
 
 **Lexers** and **parsers** are two categories of tools that you can use to perform this process.
 


### PR DESCRIPTION
This is a big simplification of the process that goes into the compilation programming languages. -->  This is a big simplification of the process that goes into the compilation **of** programming languages.