### PR TITLE
docs: rework dokka generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,2 @@
-plugins {
-    id 'org.jetbrains.dokka'
-}
-
-repositories {
-    mavenCentral()
-}
-
 group = "guru.zoroark.tegral"
 version = rootProject.file('version.txt').text.trim()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     def pluginsDef = [
         libs.plugins.kotlin,
         libs.plugins.kotlinSerialization,
-        libs.plugins.dokka,
+        libs.plugins.dokkatoo,
         libs.plugins.detekt,
         libs.plugins.versions,
         libs.plugins.gradleTestLogger,

--- a/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-published-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-published-library-conventions.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'guru.zoroark.tegral.kotlin-common-conventions'
     id 'guru.zoroark.tegral.publish-conventions'
-    id 'org.jetbrains.dokka'
+    id 'dev.adamko.dokkatoo'
     id 'org.jetbrains.kotlinx.binary-compatibility-validator'
     id 'maven-publish'
     id 'signing'
@@ -14,13 +14,23 @@ detekt {
     buildUponDefaultConfig = true
 }
 
-tasks.dokkaHtmlPartial {
-    dokkaSourceSets {
-        configureEach {
+afterEvaluate {
+    dokkatoo {
+        //moduleName = project.ext.humanName
+
+        dokkatooSourceSets.configureEach {
             includes.from("MODULE.md")
         }
     }
 }
+
+//tasks.dokkaHtmlPartial {
+//    dokkaSourceSets {
+//        configureEach {
+//            includes.from("MODULE.md")
+//        }
+//    }
+//}
 
 java {
     withSourcesJar()

--- a/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-published-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-published-library-conventions.gradle
@@ -16,8 +16,6 @@ detekt {
 
 afterEvaluate {
     dokkatoo {
-        //moduleName = project.ext.humanName
-
         dokkatooSourceSets.configureEach {
             includes.from("MODULE.md")
         }

--- a/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-published-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-published-library-conventions.gradle
@@ -22,14 +22,6 @@ afterEvaluate {
     }
 }
 
-//tasks.dokkaHtmlPartial {
-//    dokkaSourceSets {
-//        configureEach {
-//            includes.from("MODULE.md")
-//        }
-//    }
-//}
-
 java {
     withSourcesJar()
     withJavadocJar()

--- a/code-coverage/build.gradle
+++ b/code-coverage/build.gradle
@@ -7,43 +7,8 @@ repositories {
     mavenCentral()
 }
 
-def projects = [
-    ':tegral-config:tegral-config-core',
-    ':tegral-core',
-    ':tegral-di:tegral-di-core',
-    ':tegral-di:tegral-di-services',
-    ':tegral-di:tegral-di-test',
-    ':tegral-di:tegral-di-test-mockk',
-    ':tegral-featureful',
-    ':tegral-logging',
-    ':tegral-niwen:tegral-niwen-lexer',
-    ':tegral-niwen:tegral-niwen-parser',
-    ':tegral-openapi:tegral-openapi-cli',
-    ':tegral-openapi:tegral-openapi-dsl',
-    ':tegral-openapi:tegral-openapi-feature',
-    ':tegral-openapi:tegral-openapi-ktor',
-    ':tegral-openapi:tegral-openapi-ktor-resources',
-    ':tegral-openapi:tegral-openapi-ktorui',
-    ':tegral-openapi:tegral-openapi-scriptdef',
-    ':tegral-openapi:tegral-openapi-scripthost',
-    ':tegral-prismakt:tegral-prismakt-generator',
-    ':tegral-services:tegral-services-api',
-    ':tegral-services:tegral-services-feature',
-    ':tegral-utils:tegral-utils-logtools',
-    ':tegral-web:tegral-web-appdefaults',
-    ':tegral-web:tegral-web-appdsl',
-    ':tegral-web:tegral-web-apptest',
-    ':tegral-web:tegral-web-config',
-    ':tegral-web:tegral-web-controllers',
-    ':tegral-web:tegral-web-controllers-test',
-    ':tegral-web:tegral-web-greeter',
-    ':e2e-tests:run-with-java-11',
-    ':e2e-tests:run-with-java-17',
-    ':e2e-tests:run-without-config'
-]
-
 dependencies {
-    for (projectPath in projects) {
+    for (projectPath in gradle.ext.testProjects) {
         aggregatedProjects project(projectPath)
     }
 

--- a/code-coverage/build.gradle
+++ b/code-coverage/build.gradle
@@ -11,10 +11,6 @@ dependencies {
     for (projectPath in gradle.ext.testProjects) {
         aggregatedProjects project(projectPath)
     }
-
-    for (prismaktTestProject in project(':tegral-prismakt:tegral-prismakt-generator-tests').subprojects) {
-        aggregatedProjects prismaktTestProject
-    }
 }
 
 tasks.named('check') {

--- a/docs/blog/2022-06-02-tegral-001/index.md
+++ b/docs/blog/2022-06-02-tegral-001/index.md
@@ -50,7 +50,7 @@ Currently, Tegral has quite a few elements:
 
 - Documentation!
   - This very website
-  - The [API](pathname:///dokka) documentation, made available using Dokka.
+  - The [API](pathname:///dokka/index.html) documentation, made available using Dokka.
 - Libraries!
   - And quite a lot of them! Just dig into the documentation to find out what the different components can all do for you.
   - Most notably, Tegral includes a [powerful DI framework called Tegral DI](pathname:///docs/modules/core/di) that is the successor to [Shedinja](https://shedinja.zoroark.guru).

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -85,7 +85,7 @@ export default {
             label: "About",
           },
           {
-            href: "pathname:///dokka",
+            href: "pathname:///dokka/index.html",
             label: "API",
             position: "right",
           },
@@ -118,7 +118,7 @@ export default {
               },
               {
                 label: "API documentation (Dokka)",
-                to: "pathname:///dokka",
+                to: "pathname:///dokka/index.html",
               },
             ],
           },

--- a/dokka/build.gradle
+++ b/dokka/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id "dev.adamko.dokkatoo"
+}
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    dokkaHtml {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+dokkatoo { 
+    moduleName = "Tegral API reference"
+}
+
+version = rootProject.version
+
+dependencies {
+    for (projectPath in gradle.ext.publicProjects) {
+        dokkatoo project(projectPath)
+    }
+}
+
+artifacts {
+    dokkaHtml(tasks.dokkatooGeneratePublicationHtml.outputDirectory) {
+        builtBy(tasks.dokkatooGeneratePublicationHtml)
+    }
+}

--- a/e2e-tests/fundef-modules/src/main/kotlin/guru/zoroark/tegral/e2e/fundefmodules/FundefModulesApp.kt
+++ b/e2e-tests/fundef-modules/src/main/kotlin/guru/zoroark/tegral/e2e/fundefmodules/FundefModulesApp.kt
@@ -126,6 +126,7 @@ fun Application.openApi() {
     }
 }
 
+@OptIn(ExperimentalFundef::class)
 fun app() = tegral {
     install(WebControllersFeature) {
         enableFundefs = true

--- a/e2e-tests/fundef-modules/src/test/kotlin/guru/zoroark/tegral/e2e/fundefmodulesm/FundefModulesTests.kt
+++ b/e2e-tests/fundef-modules/src/test/kotlin/guru/zoroark/tegral/e2e/fundefmodulesm/FundefModulesTests.kt
@@ -28,7 +28,6 @@ import guru.zoroark.tegral.openapi.dsl.openApi
 import guru.zoroark.tegral.openapi.dsl.toJson
 import guru.zoroark.tegral.openapi.ktor.openApi
 import guru.zoroark.tegral.web.appdefaults.DefaultKtorApplication
-import guru.zoroark.tegral.web.controllers.KtorApplication
 import guru.zoroark.tegral.web.controllers.test.TegralControllerTest
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
@@ -188,9 +187,11 @@ class FundefOpenapiTest {
     fun `OpenAPI document`(): Unit = runBlocking {
         val tegralApp = app()
         try {
-            val openApiDocument = tegralApp.environment.get<DefaultKtorApplication>().application.openApi.buildOpenApiDocument()
+            val openApiDocument =
+                tegralApp.environment.get<DefaultKtorApplication>().application.openApi.buildOpenApiDocument()
             val result = jacksonObjectMapper().readValue<Map<*, *>>(openApiDocument.toJson())
-            val expected = jacksonObjectMapper().readValue<Map<*, *>>("""
+            val expected = jacksonObjectMapper().readValue<Map<*, *>>(
+                """
                 {
                   "openapi": "3.0.1",
                   "info": {
@@ -227,7 +228,8 @@ class FundefOpenapiTest {
                     }
                   }
                 }
-            """.trimIndent())
+                """.trimIndent()
+            )
             assertEquals(expected, result)
         } finally {
             tegralApp.stop()

--- a/e2e-tests/fundef-modules/src/test/resources/tegral.toml
+++ b/e2e-tests/fundef-modules/src/test/resources/tegral.toml
@@ -1,0 +1,2 @@
+[tegral.web]
+port = 8991

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 coroutines = "1.9.0"
-detekt = "1.23.6"  # waiting for a release with a fix for https://github.com/detekt/detekt/issues/7634
-dokka = "1.9.20"
+detekt = "1.23.6"          # waiting for a release with a fix for https://github.com/detekt/detekt/issues/7634
+dokkatoo = "2.3.1"
 gradleTestLogger = "4.0.0"
 hoplite = "2.8.2"
 jackson = "2.18.0"
@@ -41,7 +41,6 @@ kotlin-scripting-jvmHost = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-host = { module = "io.ktor:ktor-server-host-common", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
-ktor-server-locations = { module = "io.ktor:ktor-server-locations", version.ref = "ktor" }
 ktor-server-contentNegotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-test = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktor-server-resources = { module = "io.ktor:ktor-server-resources", version.ref = "ktor" }
@@ -106,7 +105,7 @@ commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "la
 
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokkatoo = { id = "dev.adamko.dokkatoo", version.ref = "dokkatoo" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }
 gradleTestLogger = { id = "com.adarshr.test-logger", version.ref = "gradleTestLogger" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,7 +35,7 @@ def publicProjects = [
         ':tegral-web:tegral-web-greeter',
 ]
 
-def testProjects = publicProjects + [
+def testProjects = publicProjects - ":tegral-catalog" + [
         ':tegral-prismakt:tegral-prismakt-generator-tests:mysql-types',
         ':tegral-prismakt:tegral-prismakt-generator-tests:pgsql-types',
         ':tegral-prismakt:tegral-prismakt-generator-tests:simple-dao',

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,51 +2,67 @@ plugins {
     id "com.gradle.enterprise" version "3.12.2"
 }
 
-// NOTE: When adding projects here, do not forget to also add them as dependencies in the 'code-coverage' project!
-include 'tegral-catalog',
-        'tegral-config:tegral-config-core',
-        'tegral-core',
-        'tegral-di:tegral-di-core',
-        'tegral-di:tegral-di-services',
-        'tegral-di:tegral-di-test',
-        'tegral-di:tegral-di-test-mockk',
-        'tegral-featureful',
-        'tegral-logging',
-        'tegral-niwen:tegral-niwen-lexer',
-        'tegral-niwen:tegral-niwen-parser',
-        'tegral-openapi:tegral-openapi-cli',
-        'tegral-openapi:tegral-openapi-dsl',
-        'tegral-openapi:tegral-openapi-feature',
-        'tegral-openapi:tegral-openapi-ktor',
-        'tegral-openapi:tegral-openapi-ktor-resources',
-        'tegral-openapi:tegral-openapi-ktorui',
-        'tegral-openapi:tegral-openapi-scriptdef',
-        'tegral-openapi:tegral-openapi-scripthost',
-        'tegral-prismakt:tegral-prismakt-generator',
-        'tegral-prismakt:tegral-prismakt-generator-tests:mysql-types',
-        'tegral-prismakt:tegral-prismakt-generator-tests:pgsql-types',
-        'tegral-prismakt:tegral-prismakt-generator-tests:simple-dao',
-        'tegral-prismakt:tegral-prismakt-generator-tests:simple-sql',
-        'tegral-prismakt:tegral-prismakt-generator-tests-support',
-        'tegral-services:tegral-services-api',
-        'tegral-services:tegral-services-feature',
-        'tegral-utils:tegral-utils-logtools',
-        'tegral-web:tegral-web-appdefaults',
-        'tegral-web:tegral-web-appdsl',
-        'tegral-web:tegral-web-apptest',
-        'tegral-web:tegral-web-config',
-        'tegral-web:tegral-web-controllers',
-        'tegral-web:tegral-web-controllers-test',
-        'tegral-web:tegral-web-greeter',
-        'e2e-tests:fundef-modules',
-        'e2e-tests:run-with-java-11',
-        'e2e-tests:run-with-java-17',
-        'e2e-tests:run-without-config'
+def publicProjects = [
+        ':tegral-catalog',
+        ':tegral-config:tegral-config-core',
+        ':tegral-core',
+        ':tegral-di:tegral-di-core',
+        ':tegral-di:tegral-di-services',
+        ':tegral-di:tegral-di-test',
+        ':tegral-di:tegral-di-test-mockk',
+        ':tegral-featureful',
+        ':tegral-logging',
+        ':tegral-niwen:tegral-niwen-lexer',
+        ':tegral-niwen:tegral-niwen-parser',
+        ':tegral-openapi:tegral-openapi-cli',
+        ':tegral-openapi:tegral-openapi-dsl',
+        ':tegral-openapi:tegral-openapi-feature',
+        ':tegral-openapi:tegral-openapi-ktor',
+        ':tegral-openapi:tegral-openapi-ktor-resources',
+        ':tegral-openapi:tegral-openapi-ktorui',
+        ':tegral-openapi:tegral-openapi-scriptdef',
+        ':tegral-openapi:tegral-openapi-scripthost',
+        ':tegral-prismakt:tegral-prismakt-generator',
+        ':tegral-services:tegral-services-api',
+        ':tegral-services:tegral-services-feature',
+        ':tegral-utils:tegral-utils-logtools',
+        ':tegral-web:tegral-web-appdefaults',
+        ':tegral-web:tegral-web-appdsl',
+        ':tegral-web:tegral-web-apptest',
+        ':tegral-web:tegral-web-config',
+        ':tegral-web:tegral-web-controllers',
+        ':tegral-web:tegral-web-controllers-test',
+        ':tegral-web:tegral-web-greeter',
+]
+
+def testProjects = publicProjects + [
+        ':tegral-prismakt:tegral-prismakt-generator-tests:mysql-types',
+        ':tegral-prismakt:tegral-prismakt-generator-tests:pgsql-types',
+        ':tegral-prismakt:tegral-prismakt-generator-tests:simple-dao',
+        ':tegral-prismakt:tegral-prismakt-generator-tests:simple-sql',
+        ':tegral-prismakt:tegral-prismakt-generator-tests-support',
+        ':e2e-tests:fundef-modules',
+        ':e2e-tests:run-with-java-11',
+        ':e2e-tests:run-with-java-17',
+        ':e2e-tests:run-without-config'
+]
+
+gradle.ext.publicProjects = publicProjects
+gradle.ext.testProjects = testProjects
+
+for (project in publicProjects) {
+    include project
+}
+for (project in testProjects) {
+    include project
+}
+
 
 include 'examples:simple-json-api'
 
 include 'code-coverage'
 include 'docs'
+include 'dokka'
 include 'website'
 
 gradleEnterprise {

--- a/tegral-core/build.gradle
+++ b/tegral-core/build.gradle
@@ -20,5 +20,5 @@ sourceSets {
 
 compileKotlin.dependsOn generateKotlin
 checkLicenseMain.dependsOn generateKotlin
-dokkaHtmlPartial.dependsOn generateKotlin
+dokkatooGenerateModuleHtml.dependsOn generateKotlin
 sourcesJar.dependsOn generateKotlin

--- a/tegral-web/tegral-web-controllers/api/tegral-web-controllers.api
+++ b/tegral-web/tegral-web-controllers/api/tegral-web-controllers.api
@@ -17,6 +17,7 @@ public abstract class guru/zoroark/tegral/web/controllers/KtorApplication : guru
 	public fun <init> (Lguru/zoroark/tegral/di/environment/InjectionScope;Ljava/lang/String;)V
 	public synthetic fun <init> (Lguru/zoroark/tegral/di/environment/InjectionScope;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAppName ()Ljava/lang/String;
+	public final fun getApplication ()Lio/ktor/server/application/Application;
 	public abstract fun getSettings ()Lguru/zoroark/tegral/web/controllers/KtorApplicationSettings;
 	public fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/tegral-web/tegral-web-controllers/src/main/kotlin/guru/zoroark/tegral/web/controllers/KtorApplication.kt
+++ b/tegral-web/tegral-web-controllers/src/main/kotlin/guru/zoroark/tegral/web/controllers/KtorApplication.kt
@@ -44,7 +44,16 @@ abstract class KtorApplication(
      */
     abstract val settings: KtorApplicationSettings<*, *>
 
-    private var application: EmbeddedServer<*, *>? = null
+    private var engine: EmbeddedServer<*, *>? = null
+
+    /**
+     * Instance of the underlying Ktor application.
+     *
+     * For example, you can use this to access Ktor plugins from the outside.
+     *
+     * Use with care! This application's start and stop lifecycle is managed by the [KtorApplication] instance.
+     */
+    val application get() = engine?.application ?: error("KtorApplication has not started yet")
 
     override suspend fun start() {
         val server = settings.embeddedServerFromSettings {
@@ -52,10 +61,10 @@ abstract class KtorApplication(
                 with(it) { install() }
             }
         }
-        application = server.also { it.start() }
+        engine = server.also { it.start() }
     }
 
     override suspend fun stop(): Unit = withContext(Dispatchers.IO) {
-        application?.stop(STOP_GRACE_PERIOD_MS, STOP_TIMEOUT_MS)
+        engine?.stop(STOP_GRACE_PERIOD_MS, STOP_TIMEOUT_MS)
     }
 }

--- a/website/build.gradle
+++ b/website/build.gradle
@@ -10,49 +10,24 @@ repositories {
 configurations {
     servine
     docusaurus
+    dokkaHtml
 }
 
 dependencies {
     servine 'guru.zoroark.servine:servine:0.0.2-SNAPSHOT'
     docusaurus(project(path: ":docs", configuration: 'web'))
-}
+    dokkaHtml(project(path: ":dokka", configuration: 'dokkaHtml'))
 
-import org.apache.tools.ant.filters.ReplaceTokens
-
-task rewriteDokkaLinks(type: Copy) {
-    into layout.buildDirectory.dir("dokkaHtml")
-
-    dependsOn rootProject.tasks.dokkaHtmlMultiModule
-
-    from(rootProject.layout.buildDirectory.dir("dokka/htmlMultiModule")) {
-        filesMatching(["index.html"]) {
-            filter { line ->
-                line.replaceAll("href=\"", "href=\"/dokka/")
-                    .replaceAll("src=\"", "src=\"/dokka/")
-                    .replaceAll("pathToRoot = \"\"", "pathToRoot = \"/dokka\"")
-            }
-        }
-
-        filesMatching(["scripts/pages.json"]) {
-            filter { line -> line.replaceAll("\"location\":\"", "\"location\":\"/") }
-        }
-
-        filesMatching(["scripts/navigation-loader.js"]) {
-            filter { line -> line.replaceAll("pathToRoot", "\"/dokka/\"") }
-        }
-    }
 }
 
 task assembleFiles(type: Copy) {
     into layout.buildDirectory.dir("output")
 
     from(configurations.docusaurus)
-    from(layout.buildDirectory.dir("dokkaHtml")) {
+    from(configurations.dokkaHtml) {
         into 'dokka'
     }
     from('_redirects')
-
-    dependsOn rewriteDokkaLinks
 }
 
 task serve(type: JavaExec) {


### PR DESCRIPTION
Dokka isn't great, and documentation display is broken due to how fragile the hack around URLs here. It's probable that I was just doing something stupid, but in the mean time let's switch to Dokkatoo to get some nice(r) docs going on.

Edit: for future reference, I also had to disable "pretty URLs" from Netlify's config because it rewrites `/index.html` to `/` and that breaks Dokka/Dokkatoo

Edit2: As a bonus, add access to the Ktor `Application` instance in `KtorApplication` and add a proper regression test on OpenAPI stuff