### PR TITLE
ci: fix publish actions using wrong gradle setup action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
           java-version: "11"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v4
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Publish snapshot
         env:
@@ -151,7 +151,7 @@ jobs:
           java-version: "11"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v4
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Publish release
         env:


### PR DESCRIPTION
A bit of a miss from the CI refactoring, I used the wrong action name in ci.yaml