### PR TITLE
chore(tests): use jacoco snapshot to track inline functions

### DIFF
--- a/buildSrc/src/main/groovy/guru.zoroark.tegral.coverage-aggregator.gradle
+++ b/buildSrc/src/main/groovy/guru.zoroark.tegral.coverage-aggregator.gradle
@@ -4,6 +4,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 
 configurations {
@@ -97,4 +98,8 @@ tasks.register("aggregatedCodeCoverage", JacocoReport) {
         html.required = true
         xml.required = true
     }
+}
+
+jacoco {
+    toolVersion = "0.8.13-SNAPSHOT"
 }

--- a/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/guru.zoroark.tegral.kotlin-common-conventions.gradle
@@ -10,6 +10,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {
@@ -39,4 +40,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
     }
+}
+
+jacoco {
+    toolVersion = "0.8.13-SNAPSHOT"
 }

--- a/buildSrc/src/main/groovy/guru.zoroark.tegral.pktg-e2e-test.gradle
+++ b/buildSrc/src/main/groovy/guru.zoroark.tegral.pktg-e2e-test.gradle
@@ -3,8 +3,6 @@ plugins {
 
     id 'com.github.node-gradle.node'
 
-    id 'jacoco'
-
     id 'project-report'
 }
 


### PR DESCRIPTION
Now that jacoco/jacoco#654 is done, I'm opening this PR to see how things go in terms of coverage with proper inline function coverage reporting.

HUGE PROPS to the JaCoCo team for doing the work here!
