### PR TITLE
chore: remove vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-    "github": {
-        "enabled": false
-    }
-}


### PR DESCRIPTION
Netlify is the provider used (wayyy back in #61), we don't need this anymore.

Fixes #92